### PR TITLE
fix #21 - auto-recognize linked pdfs

### DIFF
--- a/content/zotero-folder-import.ts
+++ b/content/zotero-folder-import.ts
@@ -158,11 +158,12 @@ class FolderScanner {
       try {
         if (params.link) {
           debug(`linking ${file} into ${collection ? collection.name : '<root>'}`)
-          await Zotero.Attachments.linkFromFile({
+          const item = await Zotero.Attachments.linkFromFile({
             file,
             parentItemID: false,
             collections: collection ? [ collection.id ] : undefined,
           })
+          if (file.toLowerCase().endsWith('.pdf')) pdfs.push(item)
         }
         else if (!file.endsWith('.lnk')) {
           debug(`importing ${file} into ${collection ? collection.name : '<root>'}`)


### PR DESCRIPTION
It looks like the plugin isn't adding linked items that are PDFs to the array of PDFs that should be auto-recognized. They're only added for non-linked items (see line 174):

https://github.com/retorquere/zotero-folder-import/blob/bfcf55ea7f323d4d4d2b4a724487365fb2550ebd/content/zotero-folder-import.ts#L154-L188

Zotero's dialog for adding attachments also adds linked items to the items to auto-recognize when they are top-level:

https://github.com/zotero/zotero/blob/d866a10a2b56e96631a1563572d3f2918f1f006a/chrome/content/zotero/zoteroPane.js#L4269 until L4321 (especially lines 4314 and 4319).

This changes the plugin's behavior to be more like the behavior of Zotero's attachment dialog.